### PR TITLE
Use requests.Session

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ class BadResponse(object):
 
 class TestClient(unittest.TestCase):
 
-    @patch('requests.get', return_value=BadResponse)
+    @patch('requests.Session.get', return_value=BadResponse)
     def test_get(self, get_mock):
         # Python 2.6....
         try:
@@ -30,7 +30,7 @@ class TestClient(unittest.TestCase):
             self.assertEqual(e.status_code, e.errno)
             self.assertEqual(e.reason, e.message)
 
-    @patch('requests.get', return_value=GoodResponse)
+    @patch('requests.Session.get', return_value=GoodResponse)
     def test_end_slash(self, get_mock):
         get("test", pypi_server="https://mock.test.mock/test")
         self.assertEqual(call('https://mock.test.mock/test/test/json'),

--- a/yarg/client.py
+++ b/yarg/client.py
@@ -29,6 +29,8 @@ from .exceptions import HTTPError
 from .package import json2package
 
 
+_session = None
+
 def get(package_name, pypi_server="https://pypi.python.org/pypi/"):
     """
     Constructs a request to the PyPI server and returns a
@@ -41,9 +43,13 @@ def get(package_name, pypi_server="https://pypi.python.org/pypi/"):
         >>> package = yarg.get('yarg')
         <Package yarg>
     """
+    global _session
+    if _session is None:
+        _session = requests.Session()
+
     if not pypi_server.endswith("/"):
         pypi_server = pypi_server + "/"
-    response = requests.get("{0}{1}/json".format(pypi_server,
+    response = _session.get("{0}{1}/json".format(pypi_server,
                                                  package_name))
     if response.status_code >= 300:
         raise HTTPError(status_code=response.status_code,


### PR DESCRIPTION
In [`pipreqs`](https://github.com/bndr/pipreqs) project, it using this library.
Currently, `yarg` creates new HTTPS connection every time, and `pipreqs` queries many times to pypi so it consumes many time.
I fixed to use `requests.Session` and reusing connection reduces running time to about half.
